### PR TITLE
chore: fix link to nitro docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This test suite compares available globals and Node.js built-in modules in a liv
 
 Using this data, we can make "hybrid" presets with [unjs/unenv](https://github.com/unjs/unenv), combining userland polyfills with what is available.
 
-This repo was made to develop hybrid presets for [Nitro](https://nitro.dev).
+This repo was made to develop hybrid presets for [Nitro](https://nitro.build).
 
 ## Reports
 


### PR DESCRIPTION
nitro.dev is this thing, I guess it's not yours 😳
![CleanShot 2025-02-19 at 00 50 11@2x](https://github.com/user-attachments/assets/f3a87cba-8625-49af-8dee-8af02b744e82)
